### PR TITLE
Cache orbitals when constructing basis set

### DIFF
--- a/mess/primitive.py
+++ b/mess/primitive.py
@@ -16,6 +16,7 @@ class Primitive(eqx.Module):
     alpha: float = eqx.field(converter=asfparray, default=1.0)
     lmn: Int3 = eqx.field(converter=asintarray, default=(0, 0, 0))
     norm: Optional[float] = None
+    atom_index: Optional[int] = None
 
     def __post_init__(self):
         if self.norm is None:

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -68,6 +68,7 @@ def test_minimise_ks(benchmark, mol_name):
 def test_construct_basis(benchmark):
     def harness():
         mol = molecule("water")
-        basisset(mol, "6-31g")
+        basis = basisset(mol, "6-31g")
+        return jax.block_until_ready(basis)
 
     benchmark(harness)

--- a/test/test_benchmark.py
+++ b/test/test_benchmark.py
@@ -63,3 +63,11 @@ def test_minimise_ks(benchmark, mol_name):
             return E.block_until_ready(), C.block_until_ready()
 
         benchmark(harness)
+
+
+def test_construct_basis(benchmark):
+    def harness():
+        mol = molecule("water")
+        basisset(mol, "6-31g")
+
+    benchmark(harness)


### PR DESCRIPTION
This diff introduces a cached function for looking up the basis set parameters and converting those into `mess.Orbital` instances.  The cached object is centered on the origin so the last step is to move the basis functions to the correct atom center.

This appears to save some time in the benchmark added:

```
Name (time in ms)                           Min                Max               Mean            StdDev             Median               IQR            Outliers      OPS            Rounds  Iterations
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_construct_basis (NOW)              10.6405 (1.0)      11.6807 (1.0)      11.0971 (1.0)      0.4134 (1.0)      11.1947 (1.0)      0.5950 (1.03)          2;0  90.1137 (1.0)           5           1
test_construct_basis (0001_a11be28)     23.0007 (2.16)     24.9462 (2.14)     23.5519 (2.12)     0.7894 (1.91)     23.2954 (2.08)     0.5754 (1.0)           1;1  42.4594 (0.47)          5           1
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

Still testing how this impacts the batching implementation.