### PR TITLE
Pin jax to avoid 0.7.0 as recommended in equinox

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ classifiers = [
 ]
 dependencies = [
   "equinox",
-  "jax",
+  # JAX 0.7.0 is known to be buggy with Equinox.
+  # https://github.com/patrick-kidger/equinox/issues/1084
+  "jax==0.6.2",
   "jaxtyping",
   "more-itertools",
   "optax",


### PR DESCRIPTION
See https://github.com/patrick-kidger/equinox/issues/1084

Found in [CI](https://github.com/hatemhelal/mess/actions/runs/17128543615/job/48586240009?pr=56) with the syndrome:

```
.venv/lib/python3.13/site-packages/equinox/__init__.py:3: in <module>
    from . import debug as debug, internal as internal, nn as nn
.venv/lib/python3.13/site-packages/equinox/internal/__init__.py:45: in <module>
    from ._finalise_jaxpr import (
.venv/lib/python3.13/site-packages/equinox/internal/_finalise_jaxpr.py:187: in <module>
    from ._noinline import noinline_p
.venv/lib/python3.13/site-packages/equinox/internal/_noinline.py:184: in <module>
    class _MetaBatchTransform(Module):
.venv/lib/python3.13/site-packages/equinox/internal/_noinline.py:185: in _MetaBatchTransform
    batch_axes: PyTree[batching.NotMapped | int]  # pyright: ignore
```