### PR TITLE
Add RI and THC-ISDF two-electron integral factorizations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ uv.lock
 # IDE
 .vscode
 
+# Scratch / temporary scripts
+tmp/
+
 # jupyter-book derived files
 docs/_autosummary
 docs/_build

--- a/mess/hamiltonian.py
+++ b/mess/hamiltonian.py
@@ -69,8 +69,8 @@ class HartreeFockExchange(eqx.Module):
     def __init__(self, two_electron: eqx.Module):
         self.two_electron = two_electron
 
-    def __call__(self, P: FloatNxN) -> ScalarLike:
-        K = self.two_electron.exchange(P)
+    def __call__(self, P: FloatNxN, C_occ=None) -> ScalarLike:
+        K = self.two_electron.exchange(P, C_occ)
         return -0.25 * jnp.sum(P * K)
 
 
@@ -82,7 +82,7 @@ class LDA(eqx.Module):
         self.basis = basis
         self.mesh = xcmesh_from_pyscf(basis.structure)
 
-    def __call__(self, P: FloatNxN) -> ScalarLike:
+    def __call__(self, P: FloatNxN, C_occ=None) -> ScalarLike:
         rho = density(self.basis, self.mesh, P)
         eps_xc = lda_exchange(rho) + lda_correlation_vwn(rho)
         E_xc = jnp.einsum("i,i,i", self.mesh.weights, rho, eps_xc)
@@ -97,7 +97,7 @@ class PBE(eqx.Module):
         self.basis = basis
         self.mesh = xcmesh_from_pyscf(basis.structure)
 
-    def __call__(self, P: FloatNxN) -> ScalarLike:
+    def __call__(self, P: FloatNxN, C_occ=None) -> ScalarLike:
         rho, grad_rho = density_and_grad(self.basis, self.mesh, P)
         eps_xc = gga_exchange_pbe(rho, grad_rho) + gga_correlation_pbe(rho, grad_rho)
         E_xc = jnp.einsum("i,i,i", self.mesh.weights, rho, eps_xc)
@@ -114,11 +114,11 @@ class PBE0(eqx.Module):
         self.mesh = xcmesh_from_pyscf(basis.structure)
         self.hfx = HartreeFockExchange(two_electron)
 
-    def __call__(self, P: FloatNxN) -> ScalarLike:
+    def __call__(self, P: FloatNxN, C_occ=None) -> ScalarLike:
         rho, grad_rho = density_and_grad(self.basis, self.mesh, P)
         e = 0.75 * gga_exchange_pbe(rho, grad_rho) + gga_correlation_pbe(rho, grad_rho)
         E_xc = jnp.einsum("i,i,i", self.mesh.weights, rho, e)
-        return E_xc + 0.25 * self.hfx(P)
+        return E_xc + 0.25 * self.hfx(P, C_occ)
 
 
 class B3LYP(eqx.Module):
@@ -131,14 +131,14 @@ class B3LYP(eqx.Module):
         self.mesh = xcmesh_from_pyscf(basis.structure)
         self.hfx = HartreeFockExchange(two_electron)
 
-    def __call__(self, P: FloatNxN) -> ScalarLike:
+    def __call__(self, P: FloatNxN, C_occ=None) -> ScalarLike:
         rho, grad_rho = density_and_grad(self.basis, self.mesh, P)
         eps_x = 0.08 * lda_exchange(rho) + 0.72 * gga_exchange_b88(rho, grad_rho)
         vwn_c = (1 - 0.81) * lda_correlation_vwn(rho)
         lyp_c = 0.81 * gga_correlation_lyp(rho, grad_rho)
         b3lyp_xc = eps_x + vwn_c + lyp_c
         E_xc = jnp.einsum("i,i,i", self.mesh.weights, rho, b3lyp_xc)
-        return E_xc + 0.2 * self.hfx(P)
+        return E_xc + 0.2 * self.hfx(P, C_occ)
 
 
 def build_xcfunc(
@@ -199,8 +199,8 @@ class Hamiltonian(eqx.Module):
                 case "ri":
                     self.two_electron = ri_from_basis(basis)
                 case "thc-ri":
-                    mesh = xcmesh_from_pyscf(basis.structure)
-                    self.two_electron = isdf_thc_ri(basis, mesh)
+                    mesh = xcmesh_from_pyscf(basis.structure, level=0)
+                    self.two_electron = isdf_thc_ri(basis, mesh, c_isdf=3.0)
                 case _:
                     methods = get_args(CoulombMethod)
                     raise ValueError(
@@ -209,9 +209,9 @@ class Hamiltonian(eqx.Module):
                     )
         self.xcfunc = build_xcfunc(xc_method, self.basis, self.two_electron)
 
-    def __call__(self, P: FloatNxN) -> ScalarLike:
+    def __call__(self, P: FloatNxN, C_occ=None) -> ScalarLike:
         E_core = jnp.sum(self.H_core * P)
-        E_xc = self.xcfunc(P)
+        E_xc = self.xcfunc(P, C_occ)
         J = self.two_electron.coloumb(P)
         E_es = 0.5 * jnp.sum(J * P)
         E = E_core + E_xc + E_es
@@ -258,13 +258,17 @@ def minimise(
     def f(Z, _):
         C = H.orthonormalise(Z)
         P = H.basis.density_matrix(C)
-        return H(P)
+        n_occ = H.basis.structure.num_electrons // 2
+        C_occ = C[:, :n_occ]
+        return H(P, C_occ=C_occ)
 
     solver = optx.BestSoFarMinimiser(solver)
     Z = initial_guess_fn(H.basis)
     sol = optx.minimise(f, solver, Z, max_steps=max_steps)
     C = H.orthonormalise(sol.value)
     P = H.basis.density_matrix(C)
-    E_elec = H(P)
+    n_occ = H.basis.structure.num_electrons // 2
+    C_occ = C[:, :n_occ]
+    E_elec = H(P, C_occ=C_occ)
     E_total = E_elec + nuclear_energy(H.basis.structure)
     return E_total, C, sol

--- a/mess/hamiltonian.py
+++ b/mess/hamiltonian.py
@@ -8,14 +8,15 @@ import jax
 import jax.numpy as jnp
 import jax.numpy.linalg as jnl
 import optimistix as optx
-from jaxtyping import Array, ScalarLike
+from jaxtyping import ScalarLike
 
 from mess.basis import Basis, renorm
-from mess.integrals import eri_basis, kinetic_basis, nuclear_basis, overlap_basis
+from mess.integrals import kinetic_basis, nuclear_basis, overlap_basis
 from mess.interop import to_pyscf
 from mess.mesh import Mesh, density, density_and_grad, xcmesh_from_pyscf
 from mess.orthnorm import symmetric
 from mess.structure import nuclear_energy
+from mess.two_electron import TwoElectron, ri_from_basis, isdf_thc_ri
 from mess.types import FloatNxN, OrthNormTransform
 from mess.xcfunctional import (
     gga_correlation_lyp,
@@ -28,6 +29,7 @@ from mess.xcfunctional import (
 
 xcstr = Literal["lda", "pbe", "pbe0", "b3lyp", "hfx"]
 IntegralBackend = Literal["mess", "pyscf_cart", "pyscf_sph"]
+CoulombMethod = Literal["full", "ri", "thc-ri"]
 
 
 class OneElectron(eqx.Module):
@@ -61,51 +63,10 @@ class OneElectron(eqx.Module):
             self.nuclear = jnp.array(mol.intor(f"int1e_nuc_{kind}"))
 
 
-class TwoElectron(eqx.Module):
-    eri: Array
-
-    def __init__(self, basis: Basis, backend: str = "mess"):
-        """
-
-        Args:
-            basis (Basis): the basis set used to build the electron repulsion integrals
-            backend (str, optional): Integral backend used. Defaults to "mess".
-        """
-        super().__init__()
-        if backend == "mess":
-            self.eri = eri_basis(basis)
-        elif backend.startswith("pyscf_"):
-            mol = to_pyscf(basis.structure, basis.basis_name)
-            kind = backend.split("_")[1]
-            self.eri = jnp.array(mol.intor(f"int2e_{kind}", aosym="s1"))
-
-    def coloumb(self, P: FloatNxN) -> FloatNxN:
-        """Build the Coloumb matrix (classical electrostatic) from the density matrix.
-
-        Args:
-            P (FloatNxN): the density matrix
-
-        Returns:
-            FloatNxN: Coloumb matrix
-        """
-        return jnp.einsum("kl,ijkl->ij", P, self.eri)
-
-    def exchange(self, P: FloatNxN) -> FloatNxN:
-        """Build the quantum-mechanical exchange matrix from the density matrix
-
-        Args:
-            P (FloatNxN): the density matrix
-
-        Returns:
-            FloatNxN: Exchange matrix
-        """
-        return jnp.einsum("ij,ikjl->kl", P, self.eri)
-
-
 class HartreeFockExchange(eqx.Module):
-    two_electron: TwoElectron
+    two_electron: eqx.Module
 
-    def __init__(self, two_electron: TwoElectron):
+    def __init__(self, two_electron: eqx.Module):
         self.two_electron = two_electron
 
     def __call__(self, P: FloatNxN) -> ScalarLike:
@@ -148,7 +109,7 @@ class PBE0(eqx.Module):
     mesh: Mesh
     hfx: HartreeFockExchange
 
-    def __init__(self, basis: Basis, two_electron: TwoElectron):
+    def __init__(self, basis: Basis, two_electron: eqx.Module):
         self.basis = basis
         self.mesh = xcmesh_from_pyscf(basis.structure)
         self.hfx = HartreeFockExchange(two_electron)
@@ -165,7 +126,7 @@ class B3LYP(eqx.Module):
     mesh: Mesh
     hfx: HartreeFockExchange
 
-    def __init__(self, basis: Basis, two_electron: TwoElectron):
+    def __init__(self, basis: Basis, two_electron: eqx.Module):
         self.basis = basis
         self.mesh = xcmesh_from_pyscf(basis.structure)
         self.hfx = HartreeFockExchange(two_electron)
@@ -181,7 +142,7 @@ class B3LYP(eqx.Module):
 
 
 def build_xcfunc(
-    xc_method: xcstr, basis: Basis, two_electron: Optional[TwoElectron] = None
+    xc_method: xcstr, basis: Basis, two_electron: Optional[eqx.Module] = None
 ) -> eqx.Module:
     if two_electron is None and xc_method in ("pbe0", "b3lyp"):
         raise ValueError(
@@ -211,7 +172,7 @@ class Hamiltonian(eqx.Module):
     X: FloatNxN
     H_core: FloatNxN
     basis: Basis
-    two_electron: TwoElectron
+    two_electron: eqx.Module
     xcfunc: eqx.Module
 
     def __init__(
@@ -220,6 +181,8 @@ class Hamiltonian(eqx.Module):
         ont: OrthNormTransform = symmetric,
         xc_method: xcstr = "lda",
         backend: IntegralBackend = "pyscf_sph",
+        coulomb: CoulombMethod = "full",
+        two_electron: Optional[eqx.Module] = None,
     ):
         super().__init__()
         self.basis = renorm(basis, backend) if backend != "mess" else basis
@@ -227,7 +190,23 @@ class Hamiltonian(eqx.Module):
         S = one_elec.overlap
         self.X = ont(S)
         self.H_core = one_elec.kinetic + one_elec.nuclear
-        self.two_electron = TwoElectron(basis, backend=backend)
+        if two_electron is not None:
+            self.two_electron = two_electron
+        else:
+            match coulomb:
+                case "full":
+                    self.two_electron = TwoElectron(basis, backend=backend)
+                case "ri":
+                    self.two_electron = ri_from_basis(basis)
+                case "thc-ri":
+                    mesh = xcmesh_from_pyscf(basis.structure)
+                    self.two_electron = isdf_thc_ri(basis, mesh)
+                case _:
+                    methods = get_args(CoulombMethod)
+                    raise ValueError(
+                        f"Unknown coulomb method: {coulomb}. "
+                        f"Must be one of: {', '.join(methods)}"
+                    )
         self.xcfunc = build_xcfunc(xc_method, self.basis, self.two_electron)
 
     def __call__(self, P: FloatNxN) -> ScalarLike:

--- a/mess/two_electron.py
+++ b/mess/two_electron.py
@@ -1,20 +1,23 @@
-"""Two-electron integral representations: full, RI, and THC-ISDF.
+"""Two-electron integral representations: full, RI, THC-ISDF, and hybrid RI-J/THC-K.
 
-Provides three factorizations with both Coulomb (J) and exchange (K) builds:
+Provides four factorizations with both Coulomb (J) and exchange (K) builds:
 
 - TwoElectron: full O(N^4) ERI tensor
 - TwoElectronRI: Resolution-of-Identity, O(N^2 * N_aux)
 - TwoElectronTHC: Tensor Hypercontraction via ISDF, O(N^2 * M + N * M^2)
+- TwoElectronTHCRI: Hybrid RI Coulomb (exact) + THC Exchange (approximate)
 
 References:
-    Lee, Lin, Head-Gordon, arXiv:1911.00470
+    Lee, Lin, Head-Gordon, JCTC 2020, 16, 243 (arXiv:1911.00470)
+    Dong, Hu, Lin, JCTC 2018, 14, 1311 (arXiv:1711.01531)
 """
 
 import equinox as eqx
 import jax.numpy as jnp
 import numpy as np
 from jaxtyping import Array
-from scipy.linalg import cholesky, qr, solve_triangular
+from jax.scipy.linalg import qr as jax_qr
+from scipy.linalg import cholesky, solve_triangular
 
 from mess.basis import Basis
 from mess.integrals import eri_basis
@@ -51,11 +54,12 @@ class TwoElectron(eqx.Module):
         """
         return jnp.einsum("kl,ijkl->ij", P, self.eri)
 
-    def exchange(self, P: FloatNxN) -> FloatNxN:
+    def exchange(self, P: FloatNxN, C_occ=None) -> FloatNxN:
         """Build the exchange matrix from the density matrix.
 
         Args:
             P: the density matrix
+            C_occ: ignored, accepted for interface compatibility
 
         Returns:
             Exchange matrix
@@ -87,11 +91,12 @@ class TwoElectronRI(eqx.Module):
         J = jnp.einsum("Pij,P->ij", self.B, c)
         return J
 
-    def exchange(self, P: FloatNxN) -> FloatNxN:
+    def exchange(self, P: FloatNxN, C_occ=None) -> FloatNxN:
         """Build the exchange matrix from the density matrix using RI factors.
 
         Args:
             P: density matrix (N, N)
+            C_occ: ignored, accepted for interface compatibility
 
         Returns:
             Exchange matrix K (N, N)
@@ -129,18 +134,72 @@ class TwoElectronTHC(eqx.Module):
         v = self.Z @ rho
         return jnp.einsum("iP,P,jP->ij", self.X, v, self.X)
 
-    def exchange(self, P: FloatNxN) -> FloatNxN:
+    def exchange(self, P: FloatNxN, C_occ=None) -> FloatNxN:
         """Build the exchange matrix from the density matrix using THC factors.
 
-        AO-THC-K, Eq. 38 of Lee, Lin, Head-Gordon (arXiv:1911.00470).
+        When C_occ is provided, uses the MO form (Eq. 38 of arXiv:1911.00470)
+        which costs O(N_occ*NM + N_occ*M^2) instead of the AO form's O(N^2*M + NM^2).
+
+        Args:
+            P: density matrix (N, N)
+            C_occ: occupied MO coefficients (N, N_occ). If provided, uses
+                the cheaper MO-form exchange build.
+
+        Returns:
+            Exchange matrix K (N, N)
+        """
+        if C_occ is not None:
+            psi = jnp.einsum("ui,uP->iP", C_occ, self.X)   # (N_occ, M)
+            G = 2.0 * jnp.einsum("iP,iQ->PQ", psi, psi)    # (M, M)
+        else:
+            G = jnp.einsum("iP,ij,jQ->PQ", self.X, P, self.X)  # (M, M)
+        return jnp.einsum("kP,PQ,lQ->kl", self.X, self.Z * G, self.X)
+
+
+class TwoElectronTHCRI(eqx.Module):
+    """Hybrid RI-J / THC-K two-electron integrals.
+
+    Uses exact RI Coulomb (via B) and approximate THC exchange (via X, Z).
+    This avoids the THC Coulomb error while keeping cheap THC exchange.
+
+    Stores B (N_aux, N, N), collocation X (N, M), and core Z (M, M).
+    """
+
+    B: Array   # (N_aux, N, N) — RI coefficients
+    X: FloatNxM  # (N, M) — ISDF collocation matrix
+    Z: Array   # (M, M) — THC core tensor
+
+    def coloumb(self, P: FloatNxN) -> FloatNxN:
+        """Build the Coulomb matrix using exact RI factors.
 
         Args:
             P: density matrix (N, N)
 
         Returns:
+            Coulomb matrix J (N, N)
+        """
+        c = jnp.einsum("Pmn,mn->P", self.B, P)
+        J = jnp.einsum("Pij,P->ij", self.B, c)
+        return J
+
+    def exchange(self, P: FloatNxN, C_occ=None) -> FloatNxN:
+        """Build the exchange matrix using THC factors.
+
+        When C_occ is provided, uses the MO form (Eq. 38 of arXiv:1911.00470).
+
+        Args:
+            P: density matrix (N, N)
+            C_occ: occupied MO coefficients (N, N_occ). If provided, uses
+                the cheaper MO-form exchange build.
+
+        Returns:
             Exchange matrix K (N, N)
         """
-        G = jnp.einsum("iP,ij,jQ->PQ", self.X, P, self.X)  # (M, M)
+        if C_occ is not None:
+            psi = jnp.einsum("ui,uP->iP", C_occ, self.X)   # (N_occ, M)
+            G = 2.0 * jnp.einsum("iP,iQ->PQ", psi, psi)    # (M, M)
+        else:
+            G = jnp.einsum("iP,ij,jQ->PQ", self.X, P, self.X)  # (M, M)
         return jnp.einsum("kP,PQ,lQ->kl", self.X, self.Z * G, self.X)
 
 
@@ -187,15 +246,80 @@ def _compute_ri_integrals(basis: Basis, auxbasis: str | None = None) -> np.ndarr
     return B
 
 
-def _isdf_select_points(
-    basis: Basis, mesh: Mesh, n_interp: int
+def _weighted_kmeans(
+    points: np.ndarray,
+    weights: np.ndarray,
+    n_clusters: int,
+    n_iter: int = 25,
+    seed: int = 42,
 ) -> tuple[np.ndarray, np.ndarray]:
+    """Weighted K-means clustering (Lloyd's algorithm).
+
+    Minimises sum_mu sum_{r in C_mu} w(r) * ||r - r_mu||^2.
+
+    Args:
+        points: data points (G, d)
+        weights: positive weights per point (G,)
+        n_clusters: number of clusters
+        n_iter: maximum Lloyd iterations
+        seed: random seed for reproducible initialisation
+
+    Returns:
+        centroids: cluster centres (n_clusters, d)
+        labels: cluster assignment for each point (G,)
+    """
+    G, d = points.shape
+    rng = np.random.default_rng(seed)
+
+    # Initialise centroids by sampling proportional to weights
+    probs = weights / weights.sum()
+    idx = rng.choice(G, size=n_clusters, replace=False, p=probs)
+    centroids = points[idx].copy()
+
+    pts_sq = np.sum(points ** 2, axis=1)  # (G,) — reused every iteration
+    chunk = 10_000  # process grid in chunks to limit memory
+    labels = np.empty(G, dtype=np.int32)
+
+    for _ in range(n_iter):
+        # --- Assignment: nearest centroid (chunked to cap memory) ---
+        cen_sq = np.sum(centroids ** 2, axis=1)  # (K,)
+        for s in range(0, G, chunk):
+            e = min(s + chunk, G)
+            dists = pts_sq[s:e, None] + cen_sq[None, :] - 2.0 * (points[s:e] @ centroids.T)
+            labels[s:e] = dists.argmin(axis=1)
+
+        # --- Update: weighted centroid ---
+        new_centroids = np.zeros_like(centroids)
+        for dim in range(d):
+            new_centroids[:, dim] = np.bincount(
+                labels, weights=weights * points[:, dim], minlength=n_clusters
+            )[:n_clusters]
+        total_w = np.bincount(labels, weights=weights, minlength=n_clusters)[:n_clusters]
+
+        # Handle empty clusters by reinitialising from high-weight points
+        empty = total_w < 1e-30
+        if empty.any():
+            new_centroids[empty] = points[rng.choice(G, size=int(empty.sum()), p=probs)]
+            total_w[empty] = 1.0
+
+        new_centroids /= total_w[:, None]
+
+        if np.max(np.abs(new_centroids - centroids)) < 1e-10:
+            break
+        centroids = new_centroids
+
+    return centroids, labels
+
+
+def _isdf_select_points_qrcp(
+    basis: Basis, mesh: Mesh, n_interp: int
+) -> tuple[Array, Array]:
     """Evaluate AOs on mesh and select interpolation points via QRCP.
 
-    Steps:
-        1. Evaluate AOs on mesh grid points -> phi (G, N)
-        2. Form pair products zeta (G, N^2) = phi[:,i] * phi[:,j]
-        3. Column-pivoted QR on zeta.T to select n_interp points
+    For small grids, forms pair products zeta (G, N^2) and uses QRCP directly.
+    For large grids (zeta > 2 GB), first uses CVT (weighted K-means) to
+    spatially prescreen grid points to a manageable candidate set, then
+    runs QRCP on the candidates.
 
     Args:
         basis: the Basis to evaluate AOs
@@ -203,14 +327,43 @@ def _isdf_select_points(
         n_interp: number of interpolation points
 
     Returns:
-        phi: AO values on grid (G, N) as numpy array
+        phi: AO values on grid (G, N)
         selected: indices of selected grid points (n_interp,)
     """
     N = basis.num_orbitals
-    phi = np.asarray(basis(mesh.points))  # (G, N)
-    zeta = (phi[:, :, None] * phi[:, None, :]).reshape(phi.shape[0], N * N)
-    _, _, piv = qr(zeta.T, pivoting=True)
-    selected = piv[:n_interp]
+    phi = basis(mesh.points)  # (G, N)
+    G = phi.shape[0]
+
+    zeta_bytes = G * N * N * 8
+    max_candidates = min(G, max(5 * n_interp, 5000))
+
+    if zeta_bytes < 2e9 or G <= max_candidates:
+        # Small/medium grid: full QRCP
+        zeta = (phi[:, :, None] * phi[:, None, :]).reshape(G, N * N)
+        _, _, piv = jax_qr(zeta.T, pivoting=True)
+        selected = piv[:n_interp]
+    else:
+        # Large grid: CVT spatial prescreening, then QRCP on candidates
+        weights = jnp.sum(phi * phi, axis=1)  # (G,)
+        grid_points = np.asarray(mesh.points)  # (G, 3)
+
+        _, labels = _weighted_kmeans(grid_points, np.asarray(weights), max_candidates)
+
+        # Select highest-weight grid point from each cluster
+        candidates = np.empty(max_candidates, dtype=int)
+        for k in range(max_candidates):
+            cluster_idx = np.where(labels == k)[0]
+            if len(cluster_idx) > 0:
+                candidates[k] = cluster_idx[np.argmax(weights[cluster_idx])]
+            else:
+                candidates[k] = np.argmax(weights)
+
+        # QRCP on candidate subset
+        phi_sub = phi[candidates]
+        zeta = (phi_sub[:, :, None] * phi_sub[:, None, :]).reshape(max_candidates, N * N)
+        _, _, piv = jax_qr(zeta.T, pivoting=True)
+        selected = candidates[piv[:n_interp]]
+
     return phi, selected
 
 
@@ -260,17 +413,16 @@ def isdf_thc(
     if n_interp is None:
         n_interp = 20 * N
 
-    phi, selected = _isdf_select_points(basis, mesh, n_interp)
+    phi, selected = _isdf_select_points_qrcp(basis, mesh, n_interp)
 
     # Collocation matrix
     X = jnp.array(phi[selected, :].T)  # (N, M)
 
     # Fit Z: B[ij, P] = X[i,P] * X[j,P], then Z = pinv(B) @ eri_mat @ pinv(B).T
     B = (X[:, None, :] * X[None, :, :]).reshape(N * N, n_interp)  # (N^2, M)
-    B_np = np.asarray(B)
-    B_pinv = np.linalg.pinv(B_np)  # (M, N^2)
-    eri_mat = np.asarray(eri).reshape(N * N, N * N)
-    Z = jnp.array(B_pinv @ eri_mat @ B_pinv.T)  # (M, M)
+    B_pinv = jnp.linalg.pinv(B)  # (M, N^2)
+    eri_mat = eri.reshape(N * N, N * N)
+    Z = B_pinv @ eri_mat @ B_pinv.T  # (M, M)
 
     return TwoElectronTHC(X=X, Z=Z)
 
@@ -280,32 +432,35 @@ def isdf_thc_ri(
     mesh: Mesh,
     auxbasis: str | None = None,
     c_isdf: float = 5.0,
-) -> TwoElectronTHC:
-    """Fit THC-ISDF factors from RI integrals, never forming the full ERI.
+    max_interp_ratio: int = 20,
+) -> TwoElectronTHCRI:
+    """Fit hybrid RI-J/THC-K factors from RI integrals, never forming the full ERI.
 
-    Following Lee, Lin, Head-Gordon (JCTC 2020, 16, 243), the number of
-    interpolation points is N_IP = c_ISDF * N_X, where N_X is the auxiliary
-    basis size.
+    Returns a TwoElectronTHCRI that uses exact RI Coulomb and approximate THC
+    exchange.  Following Lee, Lin, Head-Gordon (JCTC 2020, 16, 243), the number
+    of interpolation points is N_IP = c_ISDF * N_X, where N_X is the auxiliary
+    basis size.  Interpolation points are selected via CVT (weighted K-means)
+    following Dong, Hu, Lin (JCTC 2018, 14, 1311).
 
     Args:
         basis: the Basis to evaluate AOs
         mesh: quadrature mesh providing grid points
         auxbasis: auxiliary basis set name (None = PySCF auto-selects)
         c_isdf: ISDF interpolation ratio; N_IP = c_ISDF * N_aux (default: 5.0)
+        max_interp_ratio: cap N_IP at max_interp_ratio * N (default: 20)
 
     Returns:
-        TwoElectronTHC with fitted X and Z
+        TwoElectronTHCRI with RI coefficients B, collocation X, and core Z
     """
     N = basis.num_orbitals
 
     # 1. Compute RI coefficients
     B = _compute_ri_integrals(basis, auxbasis)  # (N_aux, N, N)
     N_aux = B.shape[0]
-    n_interp = round(c_isdf * N_aux)
-    B_flat = B.reshape(N_aux, N * N)  # (N_aux, N^2)
+    n_interp = min(round(c_isdf * N_aux), max_interp_ratio * N)
 
-    # 2. QRCP to select interpolation points
-    phi, selected = _isdf_select_points(basis, mesh, n_interp)
+    # 2. Select interpolation points (CVT prescreening + QRCP for large grids)
+    phi, selected = _isdf_select_points_qrcp(basis, mesh, n_interp)
 
     # 3. Collocation matrix
     X = jnp.array(phi[selected, :].T)  # (N, M)
@@ -313,12 +468,10 @@ def isdf_thc_ri(
     # 4. Fit Z via RI factored form
     # coll[ij, P] = X[i,P] * X[j,P], shape (N^2, M)
     coll = (X[:, None, :] * X[None, :, :]).reshape(N * N, n_interp)
-    coll_np = np.asarray(coll)
-    coll_pinv = np.linalg.pinv(coll_np)  # (M, N^2)
+    coll_pinv = jnp.linalg.pinv(coll)  # (M, N^2)
 
-    # W = coll_pinv @ B_flat.T  -> (M, N_aux)
-    W = coll_pinv @ B_flat.T
-    # Z = W @ W.T  -> (M, M)
-    Z = jnp.array(W @ W.T)
+    B_flat = jnp.array(B).reshape(N_aux, N * N)  # (N_aux, N^2)
+    W = coll_pinv @ B_flat.T  # (M, N_aux)
+    Z = W @ W.T  # (M, M)
 
-    return TwoElectronTHC(X=X, Z=Z)
+    return TwoElectronTHCRI(B=jnp.array(B), X=X, Z=Z)

--- a/mess/two_electron.py
+++ b/mess/two_electron.py
@@ -1,0 +1,324 @@
+"""Two-electron integral representations: full, RI, and THC-ISDF.
+
+Provides three factorizations with both Coulomb (J) and exchange (K) builds:
+
+- TwoElectron: full O(N^4) ERI tensor
+- TwoElectronRI: Resolution-of-Identity, O(N^2 * N_aux)
+- TwoElectronTHC: Tensor Hypercontraction via ISDF, O(N^2 * M + N * M^2)
+
+References:
+    Lee, Lin, Head-Gordon, arXiv:1911.00470
+"""
+
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from jaxtyping import Array
+from scipy.linalg import cholesky, qr, solve_triangular
+
+from mess.basis import Basis
+from mess.integrals import eri_basis
+from mess.interop import to_pyscf
+from mess.mesh import Mesh, xcmesh_from_pyscf
+from mess.types import FloatNxM, FloatNxN
+
+
+class TwoElectron(eqx.Module):
+    eri: Array
+
+    def __init__(self, basis: Basis, backend: str = "mess"):
+        """
+        Args:
+            basis: the basis set used to build the electron repulsion integrals
+            backend: Integral backend used. Defaults to "mess".
+        """
+        super().__init__()
+        if backend == "mess":
+            self.eri = eri_basis(basis)
+        elif backend.startswith("pyscf_"):
+            mol = to_pyscf(basis.structure, basis.basis_name)
+            kind = backend.split("_")[1]
+            self.eri = jnp.array(mol.intor(f"int2e_{kind}", aosym="s1"))
+
+    def coloumb(self, P: FloatNxN) -> FloatNxN:
+        """Build the Coulomb matrix from the density matrix.
+
+        Args:
+            P: the density matrix
+
+        Returns:
+            Coulomb matrix
+        """
+        return jnp.einsum("kl,ijkl->ij", P, self.eri)
+
+    def exchange(self, P: FloatNxN) -> FloatNxN:
+        """Build the exchange matrix from the density matrix.
+
+        Args:
+            P: the density matrix
+
+        Returns:
+            Exchange matrix
+        """
+        return jnp.einsum("ij,ikjl->kl", P, self.eri)
+
+
+class TwoElectronRI(eqx.Module):
+    """RI-J/K factored two-electron integrals.
+
+    Stores Cholesky-contracted RI coefficients B (N_aux, N, N) where
+    B^P_{mn} = sum_Q L^{-1}_{PQ} (Q|mn).
+
+    Coulomb and exchange build cost: O(N^2 * N_aux).
+    """
+
+    B: Array  # (N_aux, N, N)
+
+    def coloumb(self, P: FloatNxN) -> FloatNxN:
+        """Build the Coulomb matrix from the density matrix using RI factors.
+
+        Args:
+            P: density matrix (N, N)
+
+        Returns:
+            Coulomb matrix J (N, N)
+        """
+        c = jnp.einsum("Pmn,mn->P", self.B, P)
+        J = jnp.einsum("Pij,P->ij", self.B, c)
+        return J
+
+    def exchange(self, P: FloatNxN) -> FloatNxN:
+        """Build the exchange matrix from the density matrix using RI factors.
+
+        Args:
+            P: density matrix (N, N)
+
+        Returns:
+            Exchange matrix K (N, N)
+        """
+        D = jnp.einsum("ij,Pjl->Pil", P, self.B)   # (N_aux, N, N)
+        K = jnp.einsum("Pik,Pil->kl", self.B, D)    # (N, N)
+        return K
+
+
+class TwoElectronTHC(eqx.Module):
+    """THC-ISDF factored two-electron integrals.
+
+    Stores collocation matrix X (N, M) and core Z (M, M).
+    The ERI is approximated as:
+
+        (ij|kl) ~ sum_PQ X[i,P] X[j,P] Z[P,Q] X[k,Q] X[l,Q]
+
+    Coulomb build: O(NM + M^2).
+    Exchange build: O(N^2 M + NM^2).  (Eq. 38 of arXiv:1911.00470)
+    """
+
+    X: FloatNxM
+    Z: Array
+
+    def coloumb(self, P: FloatNxN) -> FloatNxN:
+        """Build the Coulomb matrix from the density matrix using THC factors.
+
+        Args:
+            P: density matrix (N, N)
+
+        Returns:
+            Coulomb matrix J (N, N)
+        """
+        rho = jnp.einsum("kP,lP,kl->P", self.X, self.X, P)
+        v = self.Z @ rho
+        return jnp.einsum("iP,P,jP->ij", self.X, v, self.X)
+
+    def exchange(self, P: FloatNxN) -> FloatNxN:
+        """Build the exchange matrix from the density matrix using THC factors.
+
+        AO-THC-K, Eq. 38 of Lee, Lin, Head-Gordon (arXiv:1911.00470).
+
+        Args:
+            P: density matrix (N, N)
+
+        Returns:
+            Exchange matrix K (N, N)
+        """
+        G = jnp.einsum("iP,ij,jQ->PQ", self.X, P, self.X)  # (M, M)
+        return jnp.einsum("kP,PQ,lQ->kl", self.X, self.Z * G, self.X)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _compute_ri_integrals(basis: Basis, auxbasis: str | None = None) -> np.ndarray:
+    """Compute Cholesky-contracted RI coefficients from three-center integrals.
+
+    Uses PySCF's df module to compute:
+        1. Three-center integrals (mn|P) via int3c2e
+        2. Two-center integrals (P|Q) via int2c2e
+        3. Cholesky decompose (P|Q) = L L^T
+        4. Solve L^{-1} (P|mn) to get B^P_{mn}
+
+    Args:
+        basis: the Basis for AO integrals
+        auxbasis: auxiliary basis set name (None = PySCF auto-selects)
+
+    Returns:
+        B: ndarray (N_aux, N, N) of Cholesky-contracted RI coefficients
+    """
+    from pyscf import df
+
+    mol = to_pyscf(basis.structure, basis.basis_name)
+    auxmol = df.addons.make_auxmol(mol, auxbasis)
+
+    # Three-center integrals: (N, N, N_aux)
+    int3c = df.incore.aux_e2(mol, auxmol, intor="int3c2e")
+    N = mol.nao_nr()
+    N_aux = auxmol.nao_nr()
+    int3c = int3c.reshape(N, N, N_aux)
+
+    # Two-center integrals: (N_aux, N_aux)
+    int2c = auxmol.intor("int2c2e")
+
+    # Cholesky decompose (P|Q) = L L^T, then solve L B = int3c for B = L^{-1} int3c
+    L = cholesky(int2c, lower=True)
+    int3c_flat = int3c.reshape(N * N, N_aux).T  # (N_aux, N*N)
+    B_flat = solve_triangular(L, int3c_flat, lower=True)  # (N_aux, N*N)
+    B = B_flat.reshape(N_aux, N, N)
+
+    return B
+
+
+def _isdf_select_points(
+    basis: Basis, mesh: Mesh, n_interp: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Evaluate AOs on mesh and select interpolation points via QRCP.
+
+    Steps:
+        1. Evaluate AOs on mesh grid points -> phi (G, N)
+        2. Form pair products zeta (G, N^2) = phi[:,i] * phi[:,j]
+        3. Column-pivoted QR on zeta.T to select n_interp points
+
+    Args:
+        basis: the Basis to evaluate AOs
+        mesh: quadrature mesh providing grid points
+        n_interp: number of interpolation points
+
+    Returns:
+        phi: AO values on grid (G, N) as numpy array
+        selected: indices of selected grid points (n_interp,)
+    """
+    N = basis.num_orbitals
+    phi = np.asarray(basis(mesh.points))  # (G, N)
+    zeta = (phi[:, :, None] * phi[:, None, :]).reshape(phi.shape[0], N * N)
+    _, _, piv = qr(zeta.T, pivoting=True)
+    selected = piv[:n_interp]
+    return phi, selected
+
+
+# ---------------------------------------------------------------------------
+# Public factories
+# ---------------------------------------------------------------------------
+
+def ri_from_basis(basis: Basis, auxbasis: str | None = None) -> TwoElectronRI:
+    """Factory returning a TwoElectronRI from a Basis.
+
+    Args:
+        basis: the Basis for AO integrals
+        auxbasis: auxiliary basis set name (None = PySCF auto-selects)
+
+    Returns:
+        TwoElectronRI with Cholesky-contracted RI coefficients
+    """
+    B = _compute_ri_integrals(basis, auxbasis)
+    return TwoElectronRI(B=jnp.array(B))
+
+
+def isdf_thc(
+    basis: Basis, mesh: Mesh, eri: Array, n_interp: int | None = None
+) -> TwoElectronTHC:
+    """Fit THC-ISDF factors from a reference ERI tensor.
+
+    Steps:
+        1. QRCP to select interpolation points
+        2. Build collocation matrix X = phi[selected, :].T  -> (N, M)
+        3. Fit Z via double pseudoinverse against reference ERIs
+
+    Note:
+        This function requires the full O(N^4) ERI tensor. For a more efficient
+        path that only needs O(N^2 * N_aux) three-center integrals, see
+        :func:`isdf_thc_ri`.
+
+    Args:
+        basis: the Basis to evaluate AOs
+        mesh: quadrature mesh providing grid points
+        eri: reference ERI tensor (N, N, N, N)
+        n_interp: number of interpolation points (default: 20 * N_basis)
+
+    Returns:
+        TwoElectronTHC with fitted X and Z
+    """
+    N = basis.num_orbitals
+    if n_interp is None:
+        n_interp = 20 * N
+
+    phi, selected = _isdf_select_points(basis, mesh, n_interp)
+
+    # Collocation matrix
+    X = jnp.array(phi[selected, :].T)  # (N, M)
+
+    # Fit Z: B[ij, P] = X[i,P] * X[j,P], then Z = pinv(B) @ eri_mat @ pinv(B).T
+    B = (X[:, None, :] * X[None, :, :]).reshape(N * N, n_interp)  # (N^2, M)
+    B_np = np.asarray(B)
+    B_pinv = np.linalg.pinv(B_np)  # (M, N^2)
+    eri_mat = np.asarray(eri).reshape(N * N, N * N)
+    Z = jnp.array(B_pinv @ eri_mat @ B_pinv.T)  # (M, M)
+
+    return TwoElectronTHC(X=X, Z=Z)
+
+
+def isdf_thc_ri(
+    basis: Basis,
+    mesh: Mesh,
+    auxbasis: str | None = None,
+    c_isdf: float = 5.0,
+) -> TwoElectronTHC:
+    """Fit THC-ISDF factors from RI integrals, never forming the full ERI.
+
+    Following Lee, Lin, Head-Gordon (JCTC 2020, 16, 243), the number of
+    interpolation points is N_IP = c_ISDF * N_X, where N_X is the auxiliary
+    basis size.
+
+    Args:
+        basis: the Basis to evaluate AOs
+        mesh: quadrature mesh providing grid points
+        auxbasis: auxiliary basis set name (None = PySCF auto-selects)
+        c_isdf: ISDF interpolation ratio; N_IP = c_ISDF * N_aux (default: 5.0)
+
+    Returns:
+        TwoElectronTHC with fitted X and Z
+    """
+    N = basis.num_orbitals
+
+    # 1. Compute RI coefficients
+    B = _compute_ri_integrals(basis, auxbasis)  # (N_aux, N, N)
+    N_aux = B.shape[0]
+    n_interp = round(c_isdf * N_aux)
+    B_flat = B.reshape(N_aux, N * N)  # (N_aux, N^2)
+
+    # 2. QRCP to select interpolation points
+    phi, selected = _isdf_select_points(basis, mesh, n_interp)
+
+    # 3. Collocation matrix
+    X = jnp.array(phi[selected, :].T)  # (N, M)
+
+    # 4. Fit Z via RI factored form
+    # coll[ij, P] = X[i,P] * X[j,P], shape (N^2, M)
+    coll = (X[:, None, :] * X[None, :, :]).reshape(N * N, n_interp)
+    coll_np = np.asarray(coll)
+    coll_pinv = np.linalg.pinv(coll_np)  # (M, N^2)
+
+    # W = coll_pinv @ B_flat.T  -> (M, N_aux)
+    W = coll_pinv @ B_flat.T
+    # Z = W @ W.T  -> (M, M)
+    Z = jnp.array(W @ W.T)
+
+    return TwoElectronTHC(X=X, Z=Z)

--- a/test/test_two_electron.py
+++ b/test/test_two_electron.py
@@ -1,0 +1,375 @@
+import numpy as np
+import pytest
+from jax.experimental import enable_x64
+from numpy.testing import assert_allclose
+from pyscf import dft
+
+from mess.basis import basisset
+from mess.hamiltonian import Hamiltonian
+from mess.interop import to_pyscf
+from mess.mesh import xcmesh_from_pyscf
+from mess.structure import Structure, molecule, nuclear_energy
+from mess.two_electron import (
+    TwoElectronRI,
+    TwoElectronTHC,
+    isdf_thc,
+    isdf_thc_ri,
+    ri_from_basis,
+)
+from mess.units import to_bohr
+
+
+@pytest.fixture
+def water_sto3g():
+    with enable_x64(True):
+        mol = molecule("water")
+        basis = basisset(mol, "sto-3g")
+        H = Hamiltonian(basis=basis, xc_method="hfx")
+
+        scfmol = to_pyscf(mol, basis_name="sto-3g")
+        s = dft.RKS(scfmol, xc="hf,")
+        s.kernel()
+        P = np.asarray(s.make_rdm1())
+
+        return H, P, mol, s
+
+
+@pytest.fixture
+def formaldehyde_def2svp():
+    with enable_x64(True):
+        mol = Structure(
+            atomic_number=np.array([6, 8, 1, 1]),
+            position=to_bohr(np.array([
+                [0.0000, 0.0000, 0.0000],
+                [0.0000, 0.0000, 1.2030],
+                [0.0000, 0.9437, -0.5876],
+                [0.0000, -0.9437, -0.5876],
+            ])),
+        )
+        basis = basisset(mol, "def2-SVP")
+        H = Hamiltonian(basis=basis, xc_method="hfx")
+
+        scfmol = to_pyscf(mol, basis_name="def2-SVP")
+        s = dft.RKS(scfmol, xc="hf,")
+        s.kernel()
+        P = np.asarray(s.make_rdm1())
+
+        return H, P, mol, s
+
+
+# ---------------------------------------------------------------------------
+# RI shape
+# ---------------------------------------------------------------------------
+
+def test_ri_shape(water_sto3g):
+    """Verify B has dimensions (N_aux, N, N)."""
+    with enable_x64(True):
+        H, P, mol, _ = water_sto3g
+        N = H.basis.num_orbitals
+        ri = ri_from_basis(H.basis)
+        assert ri.B.ndim == 3
+        assert ri.B.shape[1] == N
+        assert ri.B.shape[2] == N
+
+
+# ---------------------------------------------------------------------------
+# RI Coulomb
+# ---------------------------------------------------------------------------
+
+def test_ri_coulomb_water(water_sto3g):
+    """RI-J Coulomb matrix for water/sto-3g vs PySCF, atol=1e-3."""
+    with enable_x64(True):
+        H, P, mol, scf = water_sto3g
+        J_pyscf = np.asarray(scf.get_j(dm=P))
+
+        ri = ri_from_basis(H.basis)
+        J_ri = np.asarray(ri.coloumb(P))
+
+        assert_allclose(J_ri, J_pyscf, atol=1e-3)
+
+
+def test_ri_coulomb_formaldehyde(formaldehyde_def2svp):
+    """RI-J Coulomb matrix for formaldehyde/def2-SVP vs PySCF, atol=1e-3."""
+    with enable_x64(True):
+        H, P, mol, scf = formaldehyde_def2svp
+        J_pyscf = np.asarray(scf.get_j(dm=P))
+
+        ri = ri_from_basis(H.basis)
+        J_ri = np.asarray(ri.coloumb(P))
+
+        assert_allclose(J_ri, J_pyscf, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# RI Exchange
+# ---------------------------------------------------------------------------
+
+def test_ri_exchange_water(water_sto3g):
+    """RI-K exchange matrix for water/sto-3g vs PySCF, atol=1e-3."""
+    with enable_x64(True):
+        H, P, mol, scf = water_sto3g
+        K_pyscf = np.asarray(scf.get_k(dm=P))
+
+        ri = ri_from_basis(H.basis)
+        K_ri = np.asarray(ri.exchange(P))
+
+        assert_allclose(K_ri, K_pyscf, atol=1e-3)
+
+
+def test_ri_exchange_formaldehyde(formaldehyde_def2svp):
+    """RI-K exchange matrix for formaldehyde/def2-SVP vs PySCF, atol=3e-3."""
+    with enable_x64(True):
+        H, P, mol, scf = formaldehyde_def2svp
+        K_pyscf = np.asarray(scf.get_k(dm=P))
+
+        ri = ri_from_basis(H.basis)
+        K_ri = np.asarray(ri.exchange(P))
+
+        assert_allclose(K_ri, K_pyscf, atol=3e-3)
+
+
+# ---------------------------------------------------------------------------
+# RI energy
+# ---------------------------------------------------------------------------
+
+def test_ri_energy_water_lda():
+    """RI-J total energy for water/sto-3g (LDA) vs PySCF, < 1 mHa."""
+    with enable_x64(True):
+        mol = molecule("water")
+        basis = basisset(mol, "sto-3g")
+
+        scfmol = to_pyscf(mol, basis_name="sto-3g")
+        s = dft.RKS(scfmol, xc="slater,vwn_rpa")
+        s.kernel()
+        P = np.asarray(s.make_rdm1())
+        E_pyscf = s.energy_tot()
+
+        ri = ri_from_basis(basis)
+        H_ri = Hamiltonian(basis=basis, xc_method="lda", two_electron=ri)
+        E_ri = float(H_ri(P)) + float(nuclear_energy(mol))
+
+        assert abs(E_ri - E_pyscf) < 1e-3  # 1 mHa
+
+
+def test_ri_energy_water_hfx():
+    """RI-J/K total energy for water/sto-3g (HFX) vs PySCF, < 1 mHa."""
+    with enable_x64(True):
+        mol = molecule("water")
+        basis = basisset(mol, "sto-3g")
+
+        scfmol = to_pyscf(mol, basis_name="sto-3g")
+        s = dft.RKS(scfmol, xc="hf,")
+        s.kernel()
+        P = np.asarray(s.make_rdm1())
+        E_pyscf = s.energy_tot()
+
+        ri = ri_from_basis(basis)
+        H_ri = Hamiltonian(basis=basis, xc_method="hfx", two_electron=ri)
+        E_ri = float(H_ri(P)) + float(nuclear_energy(mol))
+
+        assert abs(E_ri - E_pyscf) < 1e-3  # 1 mHa
+
+
+# ---------------------------------------------------------------------------
+# THC-from-ERI shape
+# ---------------------------------------------------------------------------
+
+def test_thc_shape(water_sto3g):
+    """Verify X and Z have the expected dimensions."""
+    with enable_x64(True):
+        H, P, mol, _ = water_sto3g
+        N = H.basis.num_orbitals
+        n_interp = 20 * N
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc(H.basis, mesh, H.two_electron.eri)
+
+        assert thc.X.shape == (N, n_interp)
+        assert thc.Z.shape == (n_interp, n_interp)
+
+
+# ---------------------------------------------------------------------------
+# THC-from-ERI Coulomb
+# ---------------------------------------------------------------------------
+
+def test_thc_coulomb_water(water_sto3g):
+    """THC Coulomb matrix for water/sto-3g vs PySCF."""
+    with enable_x64(True):
+        H, P, mol, scf = water_sto3g
+        J_pyscf = np.asarray(scf.get_j(dm=P))
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc(H.basis, mesh, H.two_electron.eri)
+        J_thc = thc.coloumb(P)
+
+        assert_allclose(np.asarray(J_thc), J_pyscf, atol=1e-6)
+
+
+def test_thc_coulomb_formaldehyde(formaldehyde_def2svp):
+    """THC Coulomb matrix for formaldehyde/def2-SVP vs PySCF."""
+    with enable_x64(True):
+        H, P, mol, scf = formaldehyde_def2svp
+        J_pyscf = np.asarray(scf.get_j(dm=P))
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc(H.basis, mesh, H.two_electron.eri)
+        J_thc = thc.coloumb(P)
+
+        assert_allclose(np.asarray(J_thc), J_pyscf, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# THC-from-ERI Exchange
+# ---------------------------------------------------------------------------
+
+def test_thc_exchange_water(water_sto3g):
+    """THC exchange matrix for water/sto-3g vs PySCF."""
+    with enable_x64(True):
+        H, P, mol, scf = water_sto3g
+        K_pyscf = np.asarray(scf.get_k(dm=P))
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc(H.basis, mesh, H.two_electron.eri)
+        K_thc = np.asarray(thc.exchange(P))
+
+        assert_allclose(K_thc, K_pyscf, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# THC-from-ERI energy
+# ---------------------------------------------------------------------------
+
+def test_thc_energy_water(water_sto3g):
+    """THC total energy for water/sto-3g vs PySCF, sub-microHartree."""
+    with enable_x64(True):
+        H, P, mol, scf = water_sto3g
+        E_pyscf = scf.energy_tot()
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc(H.basis, mesh, H.two_electron.eri)
+        import equinox as eqx
+        H_thc = eqx.tree_at(lambda h: h.two_electron, H, thc)
+        E_thc = float(H_thc(P)) + float(nuclear_energy(mol))
+
+        assert abs(E_thc - E_pyscf) < 1e-6
+
+
+def test_thc_energy_formaldehyde(formaldehyde_def2svp):
+    """THC energy for formaldehyde/def2-SVP vs PySCF, < 1 mHartree."""
+    with enable_x64(True):
+        H, P, mol, scf = formaldehyde_def2svp
+        E_pyscf = scf.energy_tot()
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc(H.basis, mesh, H.two_electron.eri)
+        import equinox as eqx
+        H_thc = eqx.tree_at(lambda h: h.two_electron, H, thc)
+        E_thc = float(H_thc(P)) + float(nuclear_energy(mol))
+
+        assert abs(E_thc - E_pyscf) < 1e-3
+
+
+# ---------------------------------------------------------------------------
+# THC-from-RI Coulomb
+# ---------------------------------------------------------------------------
+
+def test_thc_ri_coulomb_water(water_sto3g):
+    """THC-from-RI Coulomb matrix for water/sto-3g vs PySCF, atol=1e-3."""
+    with enable_x64(True):
+        H, P, mol, scf = water_sto3g
+        J_pyscf = np.asarray(scf.get_j(dm=P))
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc_ri(H.basis, mesh)
+        J_thc = np.asarray(thc.coloumb(P))
+
+        assert_allclose(J_thc, J_pyscf, atol=1e-3)
+
+
+def test_thc_ri_coulomb_formaldehyde(formaldehyde_def2svp):
+    """THC-from-RI Coulomb matrix for formaldehyde/def2-SVP vs PySCF, atol=1e-3."""
+    with enable_x64(True):
+        H, P, mol, scf = formaldehyde_def2svp
+        J_pyscf = np.asarray(scf.get_j(dm=P))
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc_ri(H.basis, mesh)
+        J_thc = np.asarray(thc.coloumb(P))
+
+        assert_allclose(J_thc, J_pyscf, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# THC-from-RI Exchange
+# ---------------------------------------------------------------------------
+
+def test_thc_ri_exchange_water(water_sto3g):
+    """THC-from-RI exchange matrix for water/sto-3g vs PySCF, atol=1e-3."""
+    with enable_x64(True):
+        H, P, mol, scf = water_sto3g
+        K_pyscf = np.asarray(scf.get_k(dm=P))
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc_ri(H.basis, mesh)
+        K_thc = np.asarray(thc.exchange(P))
+
+        assert_allclose(K_thc, K_pyscf, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# THC-from-RI energy
+# ---------------------------------------------------------------------------
+
+def test_thc_ri_energy_water(water_sto3g):
+    """THC-from-RI total energy for water/sto-3g vs PySCF, < 1 mHa."""
+    with enable_x64(True):
+        H, P, mol, scf = water_sto3g
+        E_pyscf = scf.energy_tot()
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc_ri(H.basis, mesh)
+        import equinox as eqx
+        H_thc = eqx.tree_at(lambda h: h.two_electron, H, thc)
+        E_thc = float(H_thc(P)) + float(nuclear_energy(mol))
+
+        assert abs(E_thc - E_pyscf) < 1e-3  # 1 mHa
+
+
+# ---------------------------------------------------------------------------
+# Hamiltonian integration: coulomb= parameter
+# ---------------------------------------------------------------------------
+
+def test_hamiltonian_coulomb_ri():
+    """Hamiltonian with coulomb='ri' + LDA energy vs PySCF, < 1 mHa."""
+    with enable_x64(True):
+        mol = molecule("water")
+        basis = basisset(mol, "sto-3g")
+
+        scfmol = to_pyscf(mol, basis_name="sto-3g")
+        s = dft.RKS(scfmol, xc="slater,vwn_rpa")
+        s.kernel()
+        P = np.asarray(s.make_rdm1())
+        E_pyscf = s.energy_tot()
+
+        H_ri = Hamiltonian(basis=basis, xc_method="lda", coulomb="ri")
+        E_ri = float(H_ri(P)) + float(nuclear_energy(mol))
+
+        assert abs(E_ri - E_pyscf) < 1e-3
+
+
+def test_hamiltonian_coulomb_ri_hfx():
+    """Hamiltonian with coulomb='ri' + HFX energy vs PySCF, < 1 mHa."""
+    with enable_x64(True):
+        mol = molecule("water")
+        basis = basisset(mol, "sto-3g")
+
+        scfmol = to_pyscf(mol, basis_name="sto-3g")
+        s = dft.RKS(scfmol, xc="hf,")
+        s.kernel()
+        P = np.asarray(s.make_rdm1())
+        E_pyscf = s.energy_tot()
+
+        H_ri = Hamiltonian(basis=basis, xc_method="hfx", coulomb="ri")
+        E_ri = float(H_ri(P)) + float(nuclear_energy(mol))
+
+        assert abs(E_ri - E_pyscf) < 1e-3

--- a/test/test_two_electron.py
+++ b/test/test_two_electron.py
@@ -12,6 +12,7 @@ from mess.structure import Structure, molecule, nuclear_energy
 from mess.two_electron import (
     TwoElectronRI,
     TwoElectronTHC,
+    TwoElectronTHCRI,
     isdf_thc,
     isdf_thc_ri,
     ri_from_basis,
@@ -287,7 +288,7 @@ def test_thc_ri_coulomb_water(water_sto3g):
 
 
 def test_thc_ri_coulomb_formaldehyde(formaldehyde_def2svp):
-    """THC-from-RI Coulomb matrix for formaldehyde/def2-SVP vs PySCF, atol=1e-3."""
+    """THC-from-RI Coulomb matrix for formaldehyde/def2-SVP vs PySCF."""
     with enable_x64(True):
         H, P, mol, scf = formaldehyde_def2svp
         J_pyscf = np.asarray(scf.get_j(dm=P))
@@ -373,3 +374,75 @@ def test_hamiltonian_coulomb_ri_hfx():
         E_ri = float(H_ri(P)) + float(nuclear_energy(mol))
 
         assert abs(E_ri - E_pyscf) < 1e-3
+
+
+# ---------------------------------------------------------------------------
+# THC MO-form exchange
+# ---------------------------------------------------------------------------
+
+def test_thc_mo_exchange_water(water_sto3g):
+    """THC MO-form exchange matches AO-form and PySCF for water/sto-3g."""
+    with enable_x64(True):
+        H, P, mol, scf = water_sto3g
+        K_pyscf = np.asarray(scf.get_k(dm=P))
+
+        # Get occupied MO coefficients from PySCF
+        C_occ = np.asarray(scf.mo_coeff[:, scf.mo_occ > 0])
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc(H.basis, mesh, H.two_electron.eri)
+
+        K_ao = np.asarray(thc.exchange(P))
+        K_mo = np.asarray(thc.exchange(P, C_occ=C_occ))
+
+        assert_allclose(K_mo, K_ao, atol=1e-10)
+        assert_allclose(K_mo, K_pyscf, atol=1e-6)
+
+
+def test_thc_ri_mo_exchange_water(water_sto3g):
+    """THC-from-RI MO-form exchange matches AO-form and PySCF for water/sto-3g."""
+    with enable_x64(True):
+        H, P, mol, scf = water_sto3g
+        K_pyscf = np.asarray(scf.get_k(dm=P))
+
+        C_occ = np.asarray(scf.mo_coeff[:, scf.mo_occ > 0])
+
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        thc = isdf_thc_ri(H.basis, mesh)
+
+        K_ao = np.asarray(thc.exchange(P))
+        K_mo = np.asarray(thc.exchange(P, C_occ=C_occ))
+
+        assert_allclose(K_mo, K_ao, atol=1e-10)
+        assert_allclose(K_mo, K_pyscf, atol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# TwoElectronTHCRI type and hybrid Coulomb
+# ---------------------------------------------------------------------------
+
+def test_thc_ri_returns_hybrid_type(water_sto3g):
+    """isdf_thc_ri returns TwoElectronTHCRI with B, X, Z attributes."""
+    with enable_x64(True):
+        H, P, mol, _ = water_sto3g
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        hybrid = isdf_thc_ri(H.basis, mesh)
+
+        assert isinstance(hybrid, TwoElectronTHCRI)
+        assert hasattr(hybrid, "B")
+        assert hasattr(hybrid, "X")
+        assert hasattr(hybrid, "Z")
+
+
+def test_thc_ri_hybrid_coulomb_matches_pure_ri(water_sto3g):
+    """Hybrid RI-J Coulomb matches pure RI Coulomb exactly."""
+    with enable_x64(True):
+        H, P, mol, _ = water_sto3g
+        mesh = xcmesh_from_pyscf(H.basis.structure)
+        hybrid = isdf_thc_ri(H.basis, mesh)
+        ri = ri_from_basis(H.basis)
+
+        J_hybrid = np.asarray(hybrid.coloumb(P))
+        J_ri = np.asarray(ri.coloumb(P))
+
+        assert_allclose(J_hybrid, J_ri, atol=1e-10)


### PR DESCRIPTION
Summary                                                                                                                                                                                    

- Add TwoElectronRI, TwoElectronTHC, and TwoElectronTHCRI factorizations in mess/two_electron.py, each with Coulomb (J) and exchange (K) builds
- RI uses Cholesky-contracted three-center integrals from PySCF; THC-ISDF selects interpolation points via QRCP on AO pair products and fits a compact core tensor Z
- TwoElectronTHCRI combines exact RI Coulomb with approximate THC exchange — per-iteration cost drops from O(N^4) to O(N^2*M + NM^2) while keeping J exact
- Integrate into Hamiltonian via coulomb= parameter ("full", "ri", "thc-ri")
- THC exchange supports MO-form build (O(N_occ) scaling) when C_occ is provided
- Cap interpolation points at 20*N to prevent pathological M from oversized auxiliary bases
- QRCP and pseudoinverse run through JAX for GPU readiness